### PR TITLE
Validate only one blank between summary and detail

### DIFF
--- a/docs/snippets/error_code_table.rst
+++ b/docs/snippets/error_code_table.rst
@@ -21,7 +21,7 @@
 +--------------+--------------------------------------------------------------+
 | D204         | 1 blank required after class docstring.                      |
 +--------------+--------------------------------------------------------------+
-| D205         | Blank line required between one-line summary and description.|
+| D205         | 1 blank required between summary line and description.       |
 +--------------+--------------------------------------------------------------+
 | D206         | Docstring should be indented with spaces, not tabs.          |
 +--------------+--------------------------------------------------------------+

--- a/pep257.py
+++ b/pep257.py
@@ -724,7 +724,7 @@ class PEP257Checker(object):
 
     @check_for(Definition)
     def check_blank_after_summary(self, definition, docstring):
-        """D205: Blank line missing between one-line summary and description.
+        """D205: Put one blank line between summary line and description.
 
         Multi-line docstrings consist of a summary line just like a one-line
         docstring, followed by a blank line, followed by a more elaborate
@@ -735,8 +735,13 @@ class PEP257Checker(object):
         """
         if docstring:
             lines = eval(docstring).strip().split('\n')
-            if len(lines) > 1 and not is_blank(lines[1]):
-                return Error()
+            if len(lines) > 1:
+                post_summary_blanks = list(map(is_blank, lines[1:]))
+                blanks_count = sum(takewhile(bool, post_summary_blanks))
+                if blanks_count != 1:
+                    yield Error('D205: Expected 1 blank line between summary '
+                                'line and description, found %s' %
+                                blanks_count)
 
     @check_for(Definition)
     def check_indent(self, definition, docstring):

--- a/test.py
+++ b/test.py
@@ -105,9 +105,29 @@ class LeadingAndTrailingSpaceMissing:
     pass
 
 
-@expect('D205: Blank line missing between one-line summary and description')
-def asdfasdf():
+@expect('D205: Expected 1 blank line between summary line and description, '
+        'found 0')
+def multi_line_zero_separating_blanks():
     """Summary.
+    Description.
+
+    """
+
+
+@expect('D205: Expected 1 blank line between summary line and description, '
+        'found 2')
+def multi_line_two_separating_blanks():
+    """Summary.
+
+
+    Description.
+
+    """
+
+
+def multi_line_one_separating_blanks():
+    """Summary.
+
     Description.
 
     """


### PR DESCRIPTION
The previous implementation checked that at least one blank line existed
between the summary line and the detail section for a multi-line
docstring, but multiple separating blank lines were also allowed.