### PR TITLE
Changes to match new class docstring standard of PEP257

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -354,7 +354,6 @@ class Parser(object):
 
 
 class Error(object):
-
     """Error in docstring style."""
 
     # Options that define how errors are printed:
@@ -590,7 +589,6 @@ def check_for(kind, terminal=False):
 
 
 class PEP257Checker(object):
-
     """Checker for PEP 257.
 
     D10x: Missing docstrings

--- a/pep257.py
+++ b/pep257.py
@@ -691,19 +691,18 @@ class PEP257Checker(object):
 
     @check_for(Class)
     def check_blank_before_after_class(slef, class_, docstring):
-        """D20{3,4}: Class docstring should have 1 blank line around them.
+        """D20{3,4}: Class docstring should have 1 blank line after the docstring.
 
-        Insert a blank line before and after all docstrings (one-line or
-        multi-line) that document a class -- generally speaking, the class's
-        methods are separated from each other by a single blank line, and the
-        docstring needs to be offset from the first method by a blank line;
-        for symmetry, put a blank line between the class header and the
-        docstring.
+        Insert a blank line after all docstrings (one-line or multi-line)
+        that document a class -- generally speaking, the class's methods
+        are separated from each other by a single blank line, and the
+        docstring needs to be offset from the first method by a blank line.
+        
+        Note: D203 was changed by https://hg.python.org/peps/rev/9b715d8246db.
 
         """
-        # NOTE: this gives flase-positive in this case
+        # NOTE: this gives false-positive in this case
         # class Foo:
-        #
         #     """Docstring."""
         #
         #
@@ -715,8 +714,8 @@ class PEP257Checker(object):
             blanks_after = list(map(is_blank, after.split('\n')[1:]))
             blanks_before_count = sum(takewhile(bool, reversed(blanks_before)))
             blanks_after_count = sum(takewhile(bool, blanks_after))
-            if blanks_before_count != 1:
-                yield Error('D203: Expected 1 blank line *before* class '
+            if blanks_before_count != 0:
+                yield Error('D203: No blank lines allowed *before* class '
                             'docstring, found %s' % blanks_before_count)
             if not all(blanks_after) and blanks_after_count != 1:
                 yield Error('D204: Expected 1 blank line *after* class '

--- a/pep257.py
+++ b/pep257.py
@@ -688,14 +688,14 @@ class PEP257Checker(object):
                             % (function.kind, blanks_after_count))
 
     @check_for(Class)
-    def check_blank_before_after_class(slef, class_, docstring):
+    def check_blank_after_class(self, class_, docstring):
         """D20{3,4}: Class docstring should have 1 blank line after the docstring.
 
         Insert a blank line after all docstrings (one-line or multi-line)
         that document a class -- generally speaking, the class's methods
         are separated from each other by a single blank line, and the
         docstring needs to be offset from the first method by a blank line.
-        
+
         Note: D203 was changed by https://hg.python.org/peps/rev/9b715d8246db.
 
         """

--- a/test.py
+++ b/test.py
@@ -76,12 +76,13 @@ def trailing_and_leading_space():
     pass
 
 
-expect('LeadingSpaceMissing',
-       'D203: Expected 1 blank line *before* class docstring, found 0')
+expect('LeadingSpace',
+       'D203: No blank lines allowed *before* class docstring, found 1')
 
 
-class LeadingSpaceMissing:
-    """Leading space missing."""
+class LeadingSpace:
+
+    """No Leading space."""
 
 
 expect('TrailingSpace',
@@ -89,19 +90,18 @@ expect('TrailingSpace',
 
 
 class TrailingSpace:
-
     """TrailingSpace."""
     pass
 
-
-expect('LeadingAndTrailingSpaceMissing',
-       'D203: Expected 1 blank line *before* class docstring, found 0')
-expect('LeadingAndTrailingSpaceMissing',
+expect('LeadingSpaceAndTrailingSpaceMissing',
+       'D203: No blank lines allowed *before* class docstring, found 1')
+expect('LeadingSpaceAndTrailingSpaceMissing',
        'D204: Expected 1 blank line *after* class docstring, found 0')
 
 
-class LeadingAndTrailingSpaceMissing:
-    """Leading and trailing space missing."""
+class LeadingSpaceAndTrailingSpaceMissing:
+
+    """Extra Leading and trailing space missing."""
     pass
 
 

--- a/test_pep257.py
+++ b/test_pep257.py
@@ -16,7 +16,6 @@ __all__ = ()
 
 
 class Pep257Env():
-
     """An isolated environment where pep257.py can be run.
 
     Since running pep257.py as a script is affected by local config files, it's


### PR DESCRIPTION
This is to match Guido's change here:
https://hg.python.org/peps/rev/9b715d8246db
and the reason is in a comment by Guido here (first comment at bottom):

http://raspberry-python.blogspot.com/2015/01/significant-pep257-change.html