### PR TITLE
remove loglevel config from module

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -25,8 +25,7 @@ try:  # Python 3.x
 except ImportError:  # Python 2.x
     from configparser import RawConfigParser
 
-log = logging.getLogger()
-log.setLevel(logging.DEBUG)
+log = logging.getLogger(__name__)
 
 
 try:
@@ -546,6 +545,7 @@ def setup_stream_handler(options):
 
 
 def run_pep257():
+    log.setLevel(logging.DEBUG)
     opt_parser = get_option_parser()
     # setup the logger before parsing the config file, so that command line
     # arguments for debug / verbose will be printed.


### PR DESCRIPTION
by always setting the log level, you enforce that log level on every
project that attempts to depend on the pep257 module.  instead logging
should be enabled for debug when needed.

this fixes a bug in the flake8-docstrings plugin for flake8