### PR TITLE
Fix hashbang in pep257 script.

### DIFF
--- a/pep257
+++ b/pep257
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 from pep257 import main
 
 


### PR DESCRIPTION
When using `pep257` without rewriting the hashbang in the script (e.g. via `tox`), the space at the beginning of the hashbang breaks invocation of the script:

```
pep257 runtests: commands[0] | /home/buildbot/slave/lint/build/.tox/pep257/bin/pep257 ...
: No such file or directory
```