### PR TITLE
Allow NAME tokens to be put in __all__

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -377,6 +377,8 @@ class Parser(object):
             elif (self.current.kind == tk.STRING or
                   self.current.value == ','):
                 all_content += self.current.value
+            elif self.current.kind == tk.NAME:
+                all_content += "'%s'" % self.current.value
             else:
                 raise AllError('Could not evaluate contents of __all__. ')
             self.stream.move()


### PR DESCRIPTION
This allows `__all__` to include a class directly instead of just being the string name of the class.