### PR TITLE
Support '.pep257rc' as a configuration filename

### DIFF
--- a/docs/snippets/config.rst
+++ b/docs/snippets/config.rst
@@ -1,6 +1,6 @@
 ``pep257`` supports `ini`-like configuration files. In order for ``pep257`` to
-use it, it must be named ``setup.cfg``, ``tox.ini`` or ``.pep257`` and have
-a ``[pep257]`` section.
+use it, it must be named ``setup.cfg``, ``tox.ini``, ``.pep257``, or
+``.pep257rc`` and have a ``[pep257]`` section.
 
 When searching for a configuration file, ``pep257`` looks for one of the file
 specified above `in that exact order`. If a configuration file was not found,

--- a/src/pep257.py
+++ b/src/pep257.py
@@ -755,7 +755,7 @@ class ConfigurationParser(object):
     DEFAULT_MATCH_DIR_RE = '[^\.].*'
     DEFAULT_CONVENTION = conventions.pep257
 
-    PROJECT_CONFIG_FILES = ('setup.cfg', 'tox.ini', '.pep257')
+    PROJECT_CONFIG_FILES = ('setup.cfg', 'tox.ini', '.pep257', '.pep257rc')
 
     def __init__(self):
         """Create a configuration parser."""


### PR DESCRIPTION
PEP8 and PyLint use `.pep8rc` and `.pylintrc`, respectively, so I thought it would be good for PEP257 to support the “rc” convention as well.