### PR TITLE
Remove `collect` from `__all__`

### DIFF
--- a/src/pep257.py
+++ b/src/pep257.py
@@ -61,7 +61,7 @@ except AttributeError:
 
 
 __version__ = '0.7.1-alpha'
-__all__ = ('check', 'collect')
+__all__ = ('check')
 
 NO_VIOLATIONS_RETURN_CODE = 0
 VIOLATIONS_RETURN_CODE = 1


### PR DESCRIPTION
The collect function was removed in a0dcb0c2,
however it was not removed from `__all__`.