### PR TITLE
Stabilise state during Parser.consume assert

### DIFF
--- a/src/pep257.py
+++ b/src/pep257.py
@@ -268,7 +268,9 @@ class Parser(object):
     line = property(lambda self: self.stream.line)
 
     def consume(self, kind):
-        assert self.stream.move().kind == kind
+        """Consume one token and verify it is of the expected kind."""
+        next_token = self.stream.move()
+        assert next_token.kind == kind
 
     def leapfrog(self, kind, value=None):
         """Skip tokens in the stream until a certain token kind is reached.


### PR DESCRIPTION
py.test emits a warning when state is modified during an assert,
as py.test attempts to inspect the variables within an assert.

Also add a docstring for Parser.consume.